### PR TITLE
Use base package name in use-package example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Then load any flavor:
 ### use-package (with package-vc)
 
 ```elisp
-(use-package batppuccin-mocha-theme
+(use-package batppuccin
   :vc (:url "https://github.com/bbatsov/batppuccin-emacs" :rev :newest)
   :config
   (load-theme 'batppuccin-mocha t))


### PR DESCRIPTION
Sorry, I'm not sure what the correct names are for package contents, but I believe we want to use batppuccin-themes as the package name for use-package instead of a specific theme file in the package.

-----------------

- [ ] The commits are consistent with our [contribution guidelines](../blob/main/CONTRIBUTING.md)
    - This file does not exist
- [N/A] You've added a before/after screenshot illustrating your changes visually
- [N/A] You've updated the [changelog](../blob/main/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing configuration options)