### PR TITLE
Add test suite with Eldev, buttercup, and GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    paths-ignore: ['**.md']
+  pull_request:
+    paths-ignore: ['**.md']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{matrix.emacs_version == 'snapshot'}}
+
+    strategy:
+      matrix:
+        # Earliest supported + latest in each stable branch + snapshot.
+        emacs_version: ['27.2', '28.2', '29.4', '30.1', 'snapshot']
+
+    steps:
+    - name: Set up Emacs
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{matrix.emacs_version}}
+
+    - name: Install Eldev
+      run: curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/github-eldev | sh
+
+    - name: Check out the source code
+      uses: actions/checkout@v4
+
+    - name: Run tests
+      run: |
+        eldev -dtT buttercup

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,11 @@
 # Emacs directory-local variables
 .dir-locals-2.el
 
-# Cask / Eask
+# Cask / Eask / Eldev
 .cask/
 dist/
+.eldev/
+*-autoloads.el
 
 # Claude Code
 .claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ request. Please, try to follow these guidelines when you do so.
   by role (e.g. functions → blue, keywords → mauve, strings → green) and
   mention your reasoning in the PR.
 * Verify your Emacs Lisp code with `checkdoc` (<kbd>C-c ? d</kbd>).
+* Run the test suite with `eldev buttercup` and, where practical, add a
+  test for the behavior you're changing.
 * Add a before/after screenshot illustrating visually your changes.
 * Open a [pull request][4] that relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,8 @@
+; -*- mode: emacs-lisp; lexical-binding: t; no-byte-compile: t -*-
+
+(eldev-use-package-archive 'gnu)
+(eldev-use-package-archive 'melpa)
+
+(eldev-add-extra-dependencies 'test 'buttercup)
+
+(eldev-use-plugin 'autoloads)

--- a/test/batppuccin-test.el
+++ b/test/batppuccin-test.el
@@ -1,0 +1,159 @@
+;;; batppuccin-test.el --- Tests for batppuccin -*- lexical-binding: t -*-
+
+;;; Commentary:
+;;
+;; Buttercup test suite for the batppuccin theme family.
+;;
+;; Face assertions read directly from the `theme-face' property rather
+;; than going through `face-attribute' - in batch mode, faces aren't
+;; recomputed to reflect theme specs, so `face-attribute' would miss
+;; what the theme actually sets.  `theme-face' is the source of truth.
+;;
+
+;;; Code:
+
+(require 'buttercup)
+(require 'batppuccin)
+
+;; Make theme files loadable.
+(let ((dir (file-name-directory
+            (or load-file-name buffer-file-name default-directory))))
+  (add-to-list 'custom-theme-load-path
+               (expand-file-name ".." dir)))
+
+(defvar batppuccin-test--variants
+  '(batppuccin-mocha batppuccin-macchiato batppuccin-frappe batppuccin-latte)
+  "All theme variants exercised by the suite.")
+
+(defun batppuccin-test--reload (variant)
+  "Disable any active Batppuccin theme and (re-)load VARIANT.
+Reloading re-evaluates the theme file, which picks up any let-bound
+`batppuccin-scale-headings' the caller wants to exercise."
+  (dolist (v batppuccin-test--variants)
+    (when (custom-theme-enabled-p v)
+      (disable-theme v))
+    ;; Force the theme file to be re-read on the next `load-theme'.
+    (put v 'theme-settings nil)
+    (setq custom-known-themes (delq v custom-known-themes)))
+  (load-theme variant t))
+
+(defun batppuccin-test--face-attr (face variant attr)
+  "Return ATTR from FACE's theme-face spec for VARIANT, or nil.
+Reads directly from the theme-face property so we don't depend on
+frame-side face recomputation (which is unreliable in batch)."
+  (let* ((theme-face (get face 'theme-face))
+         (entry     (assoc variant theme-face))
+         (specs     (cadr entry))
+         (first     (car specs))
+         (props     (cadr first)))
+    (plist-get props attr)))
+
+;;; Heading scaling
+
+(describe "batppuccin-scale-headings"
+  (after-each
+    (dolist (v batppuccin-test--variants)
+      (when (custom-theme-enabled-p v)
+        (disable-theme v))))
+
+  (describe "when enabled (default)"
+    (before-each
+      (let ((batppuccin-scale-headings t))
+        (batppuccin-test--reload 'batppuccin-mocha)))
+
+    (it "scales outline-1..3"
+      (expect (batppuccin-test--face-attr 'outline-1 'batppuccin-mocha :height) :to-equal 1.3)
+      (expect (batppuccin-test--face-attr 'outline-2 'batppuccin-mocha :height) :to-equal 1.2)
+      (expect (batppuccin-test--face-attr 'outline-3 'batppuccin-mocha :height) :to-equal 1.1))
+
+    (it "leaves outline-4..8 without a :height"
+      (dolist (face '(outline-4 outline-5 outline-6 outline-7 outline-8))
+        (expect (batppuccin-test--face-attr face 'batppuccin-mocha :height) :to-be nil)))
+
+    (it "scales org-document-title via h-doc"
+      (expect (batppuccin-test--face-attr 'org-document-title 'batppuccin-mocha :height) :to-equal 1.4))
+
+    (it "scales info-title-1..3"
+      (expect (batppuccin-test--face-attr 'info-title-1 'batppuccin-mocha :height) :to-equal 1.3)
+      (expect (batppuccin-test--face-attr 'info-title-2 'batppuccin-mocha :height) :to-equal 1.2)
+      (expect (batppuccin-test--face-attr 'info-title-3 'batppuccin-mocha :height) :to-equal 1.1))
+
+    (it "scales shr-h1..3"
+      (expect (batppuccin-test--face-attr 'shr-h1 'batppuccin-mocha :height) :to-equal 1.3)
+      (expect (batppuccin-test--face-attr 'shr-h2 'batppuccin-mocha :height) :to-equal 1.2)
+      (expect (batppuccin-test--face-attr 'shr-h3 'batppuccin-mocha :height) :to-equal 1.1))
+
+    (it "does not set :height on org-level-N (org inherits via outline)"
+      ;; We leave org-level-N as a plain :inherit so that outline scaling
+      ;; flows through. Setting :height directly would override the
+      ;; inheritance chain.
+      (dolist (face '(org-level-1 org-level-2 org-level-3))
+        (expect (batppuccin-test--face-attr face 'batppuccin-mocha :height) :to-be nil))))
+
+  (describe "when disabled"
+    (before-each
+      (let ((batppuccin-scale-headings nil))
+        (batppuccin-test--reload 'batppuccin-mocha)))
+
+    (it "leaves outline-1..3 at 1.0"
+      (expect (batppuccin-test--face-attr 'outline-1 'batppuccin-mocha :height) :to-equal 1.0)
+      (expect (batppuccin-test--face-attr 'outline-2 'batppuccin-mocha :height) :to-equal 1.0)
+      (expect (batppuccin-test--face-attr 'outline-3 'batppuccin-mocha :height) :to-equal 1.0))
+
+    (it "leaves org-document-title at 1.0"
+      (expect (batppuccin-test--face-attr 'org-document-title 'batppuccin-mocha :height) :to-equal 1.0))
+
+    (it "leaves info / shr top levels at 1.0"
+      (dolist (face '(info-title-1 info-title-2 info-title-3
+                      shr-h1 shr-h2 shr-h3))
+        (expect (batppuccin-test--face-attr face 'batppuccin-mocha :height) :to-equal 1.0)))))
+
+;;; Palette integrity
+
+(describe "color palettes"
+  (it "define the same set of color keys across all variants"
+    (let ((mocha (sort (mapcar #'car batppuccin-mocha-colors-alist)      #'string<))
+          (mach  (sort (mapcar #'car batppuccin-macchiato-colors-alist)  #'string<))
+          (frap  (sort (mapcar #'car batppuccin-frappe-colors-alist)     #'string<))
+          (latte (sort (mapcar #'car batppuccin-latte-colors-alist)      #'string<)))
+      (expect mach  :to-equal mocha)
+      (expect frap  :to-equal mocha)
+      (expect latte :to-equal mocha)))
+
+  (it "contain all 26 canonical Catppuccin colors"
+    (dolist (alist (list batppuccin-mocha-colors-alist
+                         batppuccin-macchiato-colors-alist
+                         batppuccin-frappe-colors-alist
+                         batppuccin-latte-colors-alist))
+      (dolist (name '("bat-rosewater" "bat-flamingo" "bat-pink" "bat-mauve"
+                      "bat-red" "bat-maroon" "bat-peach" "bat-yellow"
+                      "bat-green" "bat-teal" "bat-sky" "bat-sapphire"
+                      "bat-blue" "bat-lavender"
+                      "bat-text" "bat-subtext1" "bat-subtext0"
+                      "bat-overlay2" "bat-overlay1" "bat-overlay0"
+                      "bat-surface2" "bat-surface1" "bat-surface0"
+                      "bat-base" "bat-mantle" "bat-crust"))
+        (expect (assoc name alist) :not :to-be nil))))
+
+  (it "have hex-formatted color values"
+    (dolist (alist (list batppuccin-mocha-colors-alist
+                         batppuccin-macchiato-colors-alist
+                         batppuccin-frappe-colors-alist
+                         batppuccin-latte-colors-alist))
+      (dolist (entry alist)
+        (expect (cdr entry) :to-match "\\`#[0-9a-fA-F]\\{6\\}\\'")))))
+
+;;; Variant loading smoke tests
+
+(describe "theme loading"
+  (after-each
+    (dolist (v batppuccin-test--variants)
+      (when (custom-theme-enabled-p v)
+        (disable-theme v))))
+
+  (dolist (variant batppuccin-test--variants)
+    (it (format "loads %s without error" variant)
+      (expect (load-theme variant t) :to-be-truthy)
+      (expect (custom-theme-enabled-p variant) :to-be-truthy))))
+
+;;; batppuccin-test.el ends here


### PR DESCRIPTION
Sets up a real testing story for the project. Until now there was nothing preventing regressions like the heading-height bug in #3 from shipping, so this adds an Eldev config, a buttercup suite, and a CI matrix across Emacs 27.2 through snapshot.

Tests read face specs directly from the `theme-face` property rather than `face-attribute` - in batch mode, faces aren't recomputed to reflect theme specs, so `face-attribute` would miss what the theme actually sets. A short comment in the test file explains this.

- [x] The commits are consistent with our [contribution guidelines](../blob/main/CONTRIBUTING.md)
- [ ] You've added a before/after screenshot illustrating your changes visually (N/A - infra only)
- [ ] You've updated the [changelog](../blob/main/CHANGELOG.md) (N/A - no user-visible change)
- [ ] You've updated the readme (N/A - no configuration option changes)