### PR TITLE
Remove deprecated auto-dark config

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,7 @@ day or your OS appearance setting:
 ```elisp
 (use-package auto-dark
   :config
-  (setq auto-dark-dark-theme 'batppuccin-mocha
-        auto-dark-light-theme 'batppuccin-latte)
+  (setq auto-dark-themes '((batppuccin-mocha) (batppuccin-latte)))
   (auto-dark-mode 1))
 ```
 


### PR DESCRIPTION
auto-dark has deprecated and removed the `auto-dark-dark-theme` and `auto-dark-light-theme` variables in favor of the `auto-dark-themes` var. This PR updates the README to use the new variable.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines](../blob/main/CONTRIBUTING.md)
- [ ] You've added a before/after screenshot illustrating your changes visually
- [ ] You've updated the [changelog](../blob/main/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing configuration options)

Thanks!
